### PR TITLE
Show correct info when showing more than 3 days data

### DIFF
--- a/Upcoming-iCal-Events.widget/main.coffee
+++ b/Upcoming-iCal-Events.widget/main.coffee
@@ -19,6 +19,8 @@ SHOW_DATE_TIME = true
 MAX_CHARACTERS = 50
 # Use date for day after tomorrow.
 USE_LATER_DATE = false
+# Label for all day events
+ALL_DAY_EVENT_LABEL = 'All Day'
 
 # Construct bash command using options.
 # icalBuddy has more functionality that can be used here.
@@ -56,6 +58,7 @@ style: """
     #head
         font-weight: bold
         font-size 20px
+        padding-bottom 6px
 
     #subhead
         font-weight: bold
@@ -137,7 +140,7 @@ update: (output, domEl) ->
 
             datePrefix = if (day && not USE_LATER_DATE) then day + ' ' else ''
 
-            date = ((lines[i+1].split("at"))[1]) or 'All day'
+            date = ((lines[i+1].split("at"))[1]) or ALL_DAY_EVENT_LABEL
 
             # Combine all fields
             final = name

--- a/Upcoming-iCal-Events.widget/main.coffee
+++ b/Upcoming-iCal-Events.widget/main.coffee
@@ -18,7 +18,7 @@ SHOW_DATE_TIME = true
 # Characters after this value will be replaced with ...
 MAX_CHARACTERS = 50
 # Use date for day after tomorrow.
-USE_LATER_DATE = false
+USE_DATE_AS_SUBHEADING = false
 # Label for all day events
 ALL_DAY_EVENT_LABEL = 'All Day'
 
@@ -114,7 +114,7 @@ update: (output, domEl) ->
         # Print later subheading
         else if ( lines[i+1].search(dateRegex) != -1 )
             day = lines[i+1].trim().substr(0,11)
-            dayHeader = if USE_LATER_DATE then lines[i+1].trim().substr(0,11) else 'Later'
+            dayHeader = if USE_DATE_AS_SUBHEADING then day else 'Later'
             if (!dom.text().includes(dayHeader))
                 header = dayHeader
 
@@ -138,9 +138,11 @@ update: (output, domEl) ->
             if ( name.length > MAX_CHARACTERS )
                 name = name.substr(0, MAX_CHARACTERS) + "..."
 
-            datePrefix = if (day && not USE_LATER_DATE) then day + ' ' else ''
+            datePrefix = if (day && not USE_DATE_AS_SUBHEADING) then day + ' ' else ''
 
-            date = ((lines[i+1].split("at"))[1]) or ALL_DAY_EVENT_LABEL
+            date = ((lines[i+1].split("at"))[1])
+            if !date?
+             date = ALL_DAY_EVENT_LABEL
 
             # Combine all fields
             final = name

--- a/Upcoming-iCal-Events.widget/main.coffee
+++ b/Upcoming-iCal-Events.widget/main.coffee
@@ -58,7 +58,6 @@ style: """
     #head
         font-weight: bold
         font-size 20px
-        padding-bottom 6px
 
     #subhead
         font-weight: bold

--- a/Upcoming-iCal-Events.widget/main.coffee
+++ b/Upcoming-iCal-Events.widget/main.coffee
@@ -71,6 +71,7 @@ render: (output) -> """
 
 # Update when refresh occurs
 update: (output, domEl) ->
+    dateRegex = '\\d{2}-[a-zA-Z]{3}-\\d{4}'
     lines = output.split('\n')
     bullet = lines[0][0]
     dom = $(domEl)
@@ -81,7 +82,7 @@ update: (output, domEl) ->
     lines = lines.filter (x) -> (
       ( x.startsWith(bullet) ) ||
       ( x.search('(today|tomorrow)') != -1  ) ||
-      ( x.search('\\d{2}-[a-zA-Z]{3}-\\d{4}') != -1  )
+      ( x.search(dateRegex) != -1  )
     )
 
     #Add No Events tag if nothing upcoming
@@ -108,7 +109,7 @@ update: (output, domEl) ->
             if (!dom.text().includes('Day After Tomorrow'))
                 header = 'Day After Tomorrow'
         # Print later subheading
-        else if ( lines[i+1].search('\\d{2}-[a-zA-Z]{3}-\\d{4}') != -1 )
+        else if ( lines[i+1].search(dateRegex) != -1 )
             day = lines[i+1].trim().substr(0,11)
             dayHeader = if USE_LATER_DATE then lines[i+1].trim().substr(0,11) else 'Later'
             if (!dom.text().includes(dayHeader))

--- a/Upcoming-iCal-Events.widget/main.coffee
+++ b/Upcoming-iCal-Events.widget/main.coffee
@@ -2,12 +2,17 @@
 # Last Modified: 22/03/18
 
 # Customisations
+# Refresh Frequency
+REFRESH_FREQUENCY = "1h"
 # Number of days shown from today.
-NO_DAYS_TO_SHOW = 30
+NO_DAYS_TO_SHOW = 2
 # Show which calendar you pulled from before event name.
 SHOW_CALENDER = false
 # Ignore specific calendars.
-IGNORE_CALENDER = [ 'name/UUID of calendar to ignore', 'other calendar etc' ]
+IGNORE_CALENDERS = [
+    'name/UUID of thecalendar to ignore',
+    'other calendar etc'
+]
 # Show full date including time.
 SHOW_DATE_TIME = true
 # Characters after this value will be replaced with ...
@@ -17,18 +22,18 @@ USE_LATER_DATE = false
 
 # Construct bash command using options.
 # icalBuddy has more functionality that can be used here.
-# Refer to https://hasseg.org/icalBuddy/man.html for reference.
+# Refer to https://hasseg.org/icalBuddy/man.html
 executablePath = "/usr/local/bin/icalBuddy "
 baseCommand = ' eventsToday' + '+' + NO_DAYS_TO_SHOW
 options = "-n -eed -tf '%I:%M %p' "
-if IGNORE_CALENDER
-    options = options + '-ec ' + IGNORE_CALENDER.join(',')
+if IGNORE_CALENDERS
+    options = options + '-ec ' + IGNORE_CALENDERS.join(',')
 
 # Bash command to pull events from icalBuddy
 command: executablePath + options + baseCommand
 
 # Update is called once per hour
-refreshFrequency: "1h"
+refreshFrequency: REFRESH_FREQUENCY
 
 # CSS styling
 style: """
@@ -73,9 +78,11 @@ update: (output, domEl) ->
     dom.append("""<div id="head"> Upcoming Events </div>""")
 
     # Filter out all lines that aren't event headers or dates
-    lines = lines.filter (x) -> ( ( x.startsWith(bullet) ) ||
+    lines = lines.filter (x) -> (
+      ( x.startsWith(bullet) ) ||
       ( x.search('(today|tomorrow)') != -1  ) ||
-      ( x.search('\\d{2}-[a-zA-Z]{3}-\\d{4}') != -1  ))
+      ( x.search('\\d{2}-[a-zA-Z]{3}-\\d{4}') != -1  )
+    )
 
     #Add No Events tag if nothing upcoming
     if ( lines.length == 0 )
@@ -124,9 +131,6 @@ update: (output, domEl) ->
             if nameAndCalendar[1] != undefined
                 calendar = nameAndCalendar[1].replace(')','')
 
-            if IGNORE_CALENDER.includes(calendar)
-                continue
-
             if ( name.length > MAX_CHARACTERS )
                 name = name.substr(0, MAX_CHARACTERS) + "..."
 
@@ -136,9 +140,9 @@ update: (output, domEl) ->
 
             # Combine all fields
             final = name
-            if (SHOW_DATE_TIME)
+            if SHOW_DATE_TIME
                 final = datePrefix + date + " - " + final
-            if (SHOW_CALENDER)
+            if SHOW_CALENDER
                 final = calendar + " - " + final
 
             # Add this HTML to previous


### PR DESCRIPTION
Issue: Incorrect info displayed when showing more than 3 days data
Steps to reproduce: Use command: "/usr/local/bin/icalBuddy -n eventsToday+30"

Fixes/Enhancements in this PR:
1. Display the event under the correct subheading.
2. Display correct datetime for events.
3. Move all the customisation constants to the top of the script for easy access.
4. Adds more customisation options.
